### PR TITLE
Button组件中的配图修正

### DIFF
--- a/docs/component/basic/button.md
+++ b/docs/component/basic/button.md
@@ -131,10 +131,6 @@ title: 按钮 Button
 
 自定义内容在组件slot插入即可。
 
-:::img
-![height=200](/screenshots/button/2.png)
-:::
-
 ### 示例代码
 ```wxml
 <l-button special="{{true}}" open-type="share">


### PR DESCRIPTION
Button组件中的“特殊样式按钮”配了按钮尺寸的示意图，应当去掉或替换。